### PR TITLE
Makes ChromaDB telemetry default to opt out

### DIFF
--- a/script.py
+++ b/script.py
@@ -12,6 +12,10 @@ from typing import Dict
 
 import chromadb
 
+#default opt our of chromadb telemetry
+from chromadb.config import Settings
+client = chromadb.Client(Settings(anonymized_telemetry=False))
+
 class ChromaInstance:
     def __init__(self, cutoff):
         self.client = chromadb.Client()

--- a/script.py
+++ b/script.py
@@ -12,7 +12,7 @@ from typing import Dict
 
 import chromadb
 
-#default opt our of chromadb telemetry
+#default opt out of chromadb telemetry
 from chromadb.config import Settings
 client = chromadb.Client(Settings(anonymized_telemetry=False))
 


### PR DESCRIPTION
https://docs.trychroma.com/telemetry

#default opt out of chromadb telemetry
from chromadb.config import Settings
client = chromadb.Client(Settings(anonymized_telemetry=False))

Thanks for the extension. Works great.