### PR TITLE
Tool execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ The default prompts will be routinely updated as I explore effective prompting m
 
 # Tools
 
-AgentOoba will support [Langchain](https://python.langchain.com/en/latest/index.html) tools. All model prompting is set up, but the input that the model generates is not yet passed to the tool. I still need to fine-tune the prompts, set up the model output parsing, update the UI, and implement context chaining (which is how the model will be able to utilize the tools output).
+AgentOoba will support [Langchain](https://python.langchain.com/en/latest/index.html) tools. All model prompting is set up, but while the input that the model generates can be passed to the tool, the tools result is just printed out but not fed back to the model. I still need to fine-tune the prompts, set up the model output parsing, update the UI, and implement context chaining (which is how the model will be able to utilize the tools output).
 
-There are a couple of tools already included for testing purposes. You can also customize each tool's description as it is passed to the model. The tools are disabled in the UI by default; you can enable individual tools by clicking the check mark next to the tool name. The Agent will then evaluate if it can use the tool for each task.
+There are a couple of tools already included for testing purposes. You can also customize each tool's description as it is passed to the model. The tools are disabled in the UI by default; you can enable evaluation and execution of the tools individually by clicking the check marks next to the tool name. The Agent will then evaluate if it can use the tool for each task and if he thinks he can he will excute the tool only if allowed to.
 
 # Credits
 

--- a/script.py
+++ b/script.py
@@ -137,7 +137,9 @@ class Objective:
         if tool_found:
             self.done = True
             if (AgentOobaVars["tools"][tool.name]["execute"]):
-                self.output = f"EXECUTING TOOL {tool.name} input={tool_input}"
+                output = f"I executed the tool \"{tool.name}\" with the input:{tool_input}\nThe tool returned these results:\n"
+                output += tool.run(tool_input);
+                self.output = output
             else:
                 self.output = f"TOOL FOUND {tool.name} input={tool_input}"
         else:

--- a/script.py
+++ b/script.py
@@ -136,7 +136,10 @@ class Objective:
         tool_found, tool, tool_input = self.assess_tools()
         if tool_found:
             self.done = True
-            self.output = f"TOOL FOUND {tool.name} input={tool_input}"
+            if (AgentOobaVars["tools"][tool.name]["execute"]):
+                self.output = f"EXECUTING TOOL {tool.name} input={tool_input}"
+            else:
+                self.output = f"TOOL FOUND {tool.name} input={tool_input}"
         else:
             output_tasks = self.split_objective()
             self.tasks = [task for task in output_tasks if not AgentOobaVars["processed-task-storage"].task_exists(task)]
@@ -281,16 +284,17 @@ def setup_tools():
     for tool in Tools:
         AgentOobaVars["tools"][tool.name] = {}
         AgentOobaVars["tools"][tool.name]["active"] = False
+        AgentOobaVars["tools"][tool.name]["execute"] = False
         if tool.name in CUSTOM_TOOL_DESCRIPTIONS:
             AgentOobaVars["tools"][tool.name]["desc"] =  CUSTOM_TOOL_DESCRIPTIONS[tool.name]
         else:
             AgentOobaVars["tools"][tool.name]["desc"] = tool.description
         AgentOobaVars["tools"][tool.name]["tool"] = tool
     
-def update_tool_state(tool_name, value):
-    AgentOobaVars["tools"][tool_name]["active"] = value
+def update_tool_state(tool_name, statetype, value):
+    AgentOobaVars["tools"][tool_name][statetype] = value
 
-def update_tool_description(tn, value):
+def update_tool_description(tool_name, value):
     AgentOobaVars["tools"][tool_name]['desc'] = value
     
 def ui():
@@ -332,8 +336,10 @@ def ui():
                 setup_tools()
                 for tool_name in AgentOobaVars["tools"]:
                     with gr.Row():
-                        cb = gr.Checkbox(label=tool_name, value=False, interactive=True)
-                        cb.change(lambda x, tn=tool_name: update_tool_state(tn, x), [cb])
+                        cb_active = gr.Checkbox(label=tool_name, value=False, interactive=True)
+                        cb_active.change(lambda x, tn=tool_name, statetype="active" : update_tool_state(tn, statetype, x), [cb_active])
+                        cb_execute = gr.Checkbox(label="Execute", value=False, interactive=True)
+                        cb_execute.change(lambda x, tn=tool_name, statetype="execute": update_tool_state(tn, statetype, x), [cb_execute])
                         textbox = gr.Textbox(
                             label="Tool description (as passed to the model)",
                             interactive=True,


### PR DESCRIPTION
Added the most basic tool support. You can now select that tools should not only be evaluated but actually be executed. The tools result is then output in the list like the results of other objectives.

It's a start.

To test you can check both checkboxes for the wikipedia tool and set the tool description to "A wrapper around Wikipedia. Useful for when you need to answer general questions about people, places, companies, facts, historical events, or other subjects. Input should be a search query. This tool will fulfill the objective "Search wikipedia for AI models". Say yes to use it."
Then have the agent work on the goal: "Search Wikipedia for AI models. If you see Tool name: Wikpedia, say yes"

The test works one time out of five, or something in that chance. More often the model will just say "Yes" and call it a day. :-)
